### PR TITLE
switch visits to persisted storage

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 
   // Install local package manager caches if missing (see above note re: COPY . $APP_DIR)
   // Get dependencies for the currently configured environment
-  "postCreateCommand": "mix do local.hex --force --if-missing, local.rebar --force --if-missing, deps.get --only $MIX_ENV, ecto.drop, ecto.create --quiet, ecto.migrate",
+  "postCreateCommand": "mix do local.hex --force --if-missing, local.rebar --force --if-missing, deps.get --only $MIX_ENV",
 
 
   "remoteUser": "dev",

--- a/ASSUMPTIONS.md
+++ b/ASSUMPTIONS.md
@@ -8,6 +8,8 @@
 ## On design
 
 - I assume members should not be able to request more minutes than they have in their balance. To accomplish this, I added a `:balance` field to the User struct along with a guarded `debit` function.
+- ~I assume members should not be able to request an infinite number of visits.~
+  - As implementation has continued, I now consider the prompt to be more suitable to a usage scenario in which users are able to request as many visits as they like (within the scope of their remaining balance of minutes). This means the exchange of minutes can be more easily encapsulated in a db transacton. It also makes the Transaction object make a bit more semantic sense than my original assumption.
 - I assume it is acceptable to start users with an initial balance for the first iteration.
 - I assume a reasonable stretch goal would be to allow a member to add their insurance information, which would enact a credit to their account per their plan's coverage.
 - I assume no data needs to persist beyond the duration of the evaluation of this code test- at least, for the first iteration. The first iteration utilizes Erlang Term Storage for an in-memory storage solution.

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :visilitator, Visilitator.Repo,
-  database: "postgres",
+  database: "visilitator",
   username: "postgres",
   password: "pg",
   hostname: "pg"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -3,6 +3,6 @@ import Config
 config :visilitator, Visilitator.Repo,
   username: "postgres",
   password: "pg",
-  database: "postgres",
+  database: "visilitator",
   hostname: "pg",
   pool: Ecto.Adapters.SQL.Sandbox

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -15,6 +15,6 @@ if config_env() == :prod do
   config :visilitator, Visilitator.Repo,
     username: System.get_env("DB_USERNAME", "postgres"),
     password: System.fetch_env!("DB_PASSWORD"),
-    database: System.get_env("DB_NAME", "postgres"),
+    database: System.get_env("DB_NAME", "visilitator"),
     hostname: System.get_env("DB_HOST", "pg")
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,6 +3,6 @@ import Config
 config :visilitator, Visilitator.Repo,
   username: "postgres",
   password: "pg",
-  database: "postgres",
+  database: "visilitator",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox

--- a/lib/visilitator.ex
+++ b/lib/visilitator.ex
@@ -22,26 +22,18 @@ defmodule Visilitator do
   @doc """
   Request Visit
   """
-  @spec request_visit(integer(), String.t(), pos_integer(), list(String.t())) :: :ok
-  def request_visit(user_id, date, minutes, tasks) do
-    User.lookup(user_id)
-    |> User.debit(minutes)
-
-    visit = Visit.create(user_id, date, minutes, tasks)
-    IO.puts("Your visit ID is: #{visit.id}")
+  @spec request_visit(User.t(), Date.t(), pos_integer(), list(String.t())) :: Visit.t()
+  def request_visit(user, date, minutes, tasks)
+      when user.balance > 0 and minutes <= user.balance do
+    user
+    |> Visit.create(date, minutes, tasks)
   end
 
   @doc """
   Fulfill Visit
   """
-  @spec fulfill_visit(integer(), String.t()) :: :ok
-  def fulfill_visit(user_id, visit_id) do
-    pal = User.lookup(user_id)
-    visit = Visit.lookup(visit_id)
-
-    # In a DB impl, the following updates would happen in a single transaction
-    User.fulfill(pal, visit.minutes)
-    txn = Transaction.create(visit.member_id, pal.id, visit.id)
-    IO.puts("Your transaction ID is: #{txn.id}")
+  @spec fulfill_visit(User.t(), Visit.t()) :: {Transaction.t(), User.t(), User.t()}
+  def fulfill_visit(user, visit) do
+    Transaction.create(user, visit)
   end
 end

--- a/lib/visilitator/application.ex
+++ b/lib/visilitator/application.ex
@@ -7,7 +7,6 @@ defmodule Visilitator.Application do
   @spec start(any, any) :: {:error, any} | {:ok, pid}
   def start(_type, _args) do
     # Sets up in-memory storage suitable for a PoC/MVP.
-    :ets.new(:visits, [:named_table, :public])
     :ets.new(:transactions, [:named_table, :public])
 
     children = [

--- a/lib/visilitator/transaction.ex
+++ b/lib/visilitator/transaction.ex
@@ -3,6 +3,10 @@ defmodule Visilitator.Transaction do
   Transaction object
   """
 
+  alias Visilitator.Repo
+  alias Visilitator.User
+  alias Visilitator.Visit
+
   @type t :: %__MODULE__{
           id: String.t(),
           member_id: integer(),
@@ -14,11 +18,19 @@ defmodule Visilitator.Transaction do
   @doc """
   Given member_id, pal_id, and visit_id, this function creates, persists to storage, and returns a Transaction
   """
-  @spec create(integer(), integer(), String.t()) :: t()
-  def create(member_id, pal_id, visit_id) do
+  @spec create(User.t(), Visit.t()) :: {t(), User.t(), User.t()}
+  def create(pal = %User{}, visit = %Visit{}) do
+    # Good place for an ecto multi
+    User
+    |> Repo.get(visit.member)
+    |> User.debit(visit)
+
+    pal
+    |> User.fulfill(visit)
+
     tid = UUID.uuid4()
-    txn = %__MODULE__{id: tid, member_id: member_id, pal_id: pal_id, visit_id: visit_id}
+    txn = %__MODULE__{id: tid, member_id: visit.member, pal_id: pal.id, visit_id: visit.id}
     :ets.insert(:transactions, {tid, txn})
-    txn
+    {txn, User |> Repo.get(visit.member), User |> Repo.get(pal.id)}
   end
 end

--- a/lib/visilitator/visit.ex
+++ b/lib/visilitator/visit.ex
@@ -5,7 +5,6 @@ defmodule Visilitator.Visit do
   use Ecto.Schema
 
   alias Visilitator.Repo
-  alias Visilitator.Type
 
   @type t :: %__MODULE__{}
 

--- a/lib/visilitator/visit.ex
+++ b/lib/visilitator/visit.ex
@@ -2,30 +2,31 @@ defmodule Visilitator.Visit do
   @moduledoc """
   Visit object
   """
+  use Ecto.Schema
 
-  @type t :: %__MODULE__{
-          id: String.t(),
-          member_id: integer(),
-          date: String.t(),
-          minutes: non_neg_integer(),
-          tasks: list(String.t())
-        }
-  defstruct [:id, :member_id, :date, :minutes, :tasks]
+  alias Visilitator.Repo
+  alias Visilitator.Type
+
+  @type t :: %__MODULE__{}
+
+  schema "visits" do
+    field(:member, :integer)
+    field(:date, :date)
+    field(:minutes, :integer)
+    field(:tasks, {:array, :string})
+  end
 
   @doc """
   Given user_id, date, minutes, and tasks, this function creates, persists to storage, and returns a Visit
   """
-  @spec create(integer(), String.t(), non_neg_integer(), list(String.t())) :: t()
-  def create(user_id, date, minutes, tasks) do
-    vid = UUID.uuid4()
-    visit = %__MODULE__{id: vid, member_id: user_id, date: date, minutes: minutes, tasks: tasks}
-    :ets.insert(:visits, {vid, visit})
-    visit
+  @spec create(Type.user(), Date.t(), non_neg_integer(), list(String.t())) :: t()
+  def create(user, date, minutes, tasks) when is_integer(minutes) and minutes > 0 do
+    %__MODULE__{
+      member: user.id,
+      date: date,
+      minutes: minutes,
+      tasks: tasks
+    }
+    |> Repo.insert!()
   end
-
-  @doc """
-  Given visit_id, this function returns the matching Visit from storage
-  """
-  @spec lookup(String.t()) :: t()
-  def lookup(visit_id), do: :ets.lookup_element(:visits, visit_id, 2)
 end

--- a/lib/visilitator/visit.ex
+++ b/lib/visilitator/visit.ex
@@ -5,6 +5,7 @@ defmodule Visilitator.Visit do
   use Ecto.Schema
 
   alias Visilitator.Repo
+  alias Visilitator.User
 
   @type t :: %__MODULE__{}
 
@@ -18,7 +19,7 @@ defmodule Visilitator.Visit do
   @doc """
   Given user_id, date, minutes, and tasks, this function creates, persists to storage, and returns a Visit
   """
-  @spec create(Type.user(), Date.t(), non_neg_integer(), list(String.t())) :: t()
+  @spec create(User.t(), Date.t(), non_neg_integer(), list(String.t())) :: t()
   def create(user, date, minutes, tasks) when is_integer(minutes) and minutes > 0 do
     %__MODULE__{
       member: user.id,

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Visilitator.MixProject do
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(env) when env == :test or env == :dev, do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help compile.app" to learn about applications.

--- a/priv/repo/migrations/20221112060511_create_visits.exs
+++ b/priv/repo/migrations/20221112060511_create_visits.exs
@@ -1,0 +1,12 @@
+defmodule Visilitator.Repo.Migrations.CreateVisits do
+  use Ecto.Migration
+
+  def change do
+    create table(:visits) do
+      add :member, :id
+      add :date, :date
+      add :minutes, :integer
+      add :tasks, {:array, :string}
+    end
+  end
+end

--- a/test/visilitator/user_test.exs
+++ b/test/visilitator/user_test.exs
@@ -13,4 +13,25 @@ defmodule Visilitator.UserTest do
 
     assert User |> Repo.all() |> Enum.count() == 1
   end
+
+  test "debits" do
+    member = User.create("little", "bobby", "tables")
+    visit = Visilitator.request_visit(member, ~D[2021-01-01], 50, ["foo", "bar"])
+
+    member |> User.debit(visit)
+
+    assert (User |> Repo.get(member.id)).balance == 50
+  end
+
+  test "fulfills" do
+    member = User.create("little", "bobby", "tables")
+
+    visit = Visilitator.request_visit(member, ~D[2021-01-01], 50, ["foo", "bar"])
+
+    pal =
+      User.create("port", "monteau", "wordplay@gmail.com")
+      |> User.fulfill(visit)
+
+    assert (User |> Repo.get(pal.id)).balance == 142
+  end
 end

--- a/test/visilitator_test.exs
+++ b/test/visilitator_test.exs
@@ -3,83 +3,80 @@ defmodule VisilitatorTest do
   doctest Visilitator
 
   alias Visilitator.User
+  alias Visilitator.Visit
 
   test "persists user on creation" do
     first_name = "little"
     last_name = "bobby"
     email = "tables"
 
-    %User{id: _, first_name: _, last_name: _, email: _, balance: 100} =
+    assert User |> Repo.all() |> Enum.count() == 0
+
+    %User{id: _, first_name: ^first_name, last_name: ^last_name, email: ^email, balance: 100} =
       Visilitator.create_account(first_name, last_name, email)
 
     assert User |> Repo.all() |> Enum.count() == 1
   end
 
   test "requests a visit" do
-    Visilitator.create_account("little", "bobby", "tables")
+    member = Visilitator.create_account("little", "bobby", "tables")
 
-    [member | []] = User |> Repo.all()
     date = ~D[2021-01-01]
     minutes = 30
     tasks = ["talk", "laundry"]
 
-    assert :ets.info(:visits) |> Keyword.fetch!(:size) == 0
-    Visilitator.request_visit(member.id, date, minutes, tasks)
-    assert :ets.info(:visits) |> Keyword.fetch!(:size) == 1
+    id = member.id
 
-    debited_mins = member.balance - minutes
-    assert User.lookup(member.id).balance == debited_mins
-  end
+    %Visit{member: ^id, minutes: 30, date: ^date, tasks: ^tasks} =
+      Visilitator.request_visit(member, date, minutes, tasks)
 
-  test "stops requests from members with a 0 balance of minutes" do
-    Visilitator.create_account("little", "bobby", "tables")
-    [member | []] = User |> Repo.all()
-
-    assert :ets.info(:visits) |> Keyword.fetch!(:size) == 0
-    Visilitator.request_visit(member.id, ~D[2021-01-01], 100, ["talk", "laundry"])
-
-    assert :ets.info(:visits) |> Keyword.fetch!(:size) == 1
-
-    assert catch_error(
-             Visilitator.request_visit(member.id, ~D[2021-01-02], 1, ["talk", "laundry"])
-           ) == :function_clause
-
-    assert :ets.info(:visits) |> Keyword.fetch!(:size) == 1
+    assert Visit |> Repo.all() |> Enum.count() == 1
   end
 
   test "stops members from requesting minutes beyond their balance" do
     Visilitator.create_account("little", "bobby", "tables")
     [member | []] = User |> Repo.all()
 
-    assert :ets.info(:visits) |> Keyword.fetch!(:size) == 0
+    assert Visit |> Repo.all() |> Enum.count() == 0
 
     assert catch_error(
-             Visilitator.request_visit(member.id, ~D[2021-01-01], 101, ["talk", "laundry"])
+             Visilitator.request_visit(member, ~D[2021-01-01], 101, ["talk", "laundry"])
            ) == :function_clause
 
-    assert :ets.info(:visits) |> Keyword.fetch!(:size) == 0
+    assert Visit |> Repo.all() |> Enum.count() == 0
   end
 
   test "fulfills a visit" do
-    Visilitator.create_account("little", "bobby", "tables")
-    Visilitator.create_account("first", "last", "email")
-
-    [member | [pal | []]] = User |> Repo.all()
-
-    Visilitator.request_visit(member.id, ~D[2021-01-01], 30, ["talk", "laundry"])
-
-    visit = :ets.lookup_element(:visits, :ets.first(:visits), 2)
+    member = Visilitator.create_account("little", "bobby", "tables")
+    pal = Visilitator.create_account("first", "last", "email")
+    visit = Visilitator.request_visit(member, ~D[2021-01-01], 30, ["talk", "laundry"])
 
     assert :ets.info(:transactions) |> Keyword.fetch!(:size) == 0
-    Visilitator.fulfill_visit(pal.id, visit.id)
+    Visilitator.fulfill_visit(pal, visit)
     assert :ets.info(:transactions) |> Keyword.fetch!(:size) == 1
+
+    debited_mins = member.balance - visit.minutes
+    assert (User |> Repo.get(member.id)).balance == debited_mins
 
     overhead_percent =
       Application.fetch_env!(:visilitator, Visilitator.User)
       |> Keyword.fetch!(:fulfillment_overhead_percentage)
 
     credited_mins = pal.balance + trunc(visit.minutes - visit.minutes * overhead_percent)
-    assert User.lookup(pal.id).balance == credited_mins
+    assert (User |> Repo.get(pal.id)).balance == credited_mins
+  end
+
+  test "stops requests from members with a 0 balance of minutes" do
+    member = Visilitator.create_account("little", "bobby", "tables")
+    pal = Visilitator.create_account("port", "monteau", "wordplay@gmail.com")
+    visit = Visilitator.request_visit(member, ~D[2021-01-01], 100, ["talk", "laundry"])
+    {_, member, _} = Visilitator.fulfill_visit(pal, visit)
+    member = User |> Repo.get(member.id)
+
+    assert catch_error(Visilitator.request_visit(member, ~D[2021-01-02], 1, ["talk", "laundry"])) ==
+             :function_clause
+
+    assert Visit |> Repo.all() |> Enum.count() == 1
   end
 
   setup do
@@ -87,9 +84,7 @@ defmodule VisilitatorTest do
   end
 
   defp clear_tables() do
-    :ets.delete_all_objects(:visits)
     :ets.delete_all_objects(:transactions)
-    assert :ets.info(:visits) |> Keyword.fetch!(:size) == 0
     assert :ets.info(:transactions) |> Keyword.fetch!(:size) == 0
   end
 end


### PR DESCRIPTION
# Description

Also undoes auto drop/create on container start in vscode since this defeats the purpose of a local pgdata cache

Closes #22
Closes #29
Visit part of #28

# How Has This Been Tested?

- [x] CI