### PR TITLE
mv transactional logic to Transaction

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,7 +3,7 @@ import Config
 config :visilitator,
   ecto_repos: [Visilitator.Repo]
 
-config :visilitator, Visilitator.User, fulfillment_overhead_percentage: 0.15
+config :visilitator, Visilitator.Transaction, fulfillment_overhead_percentage: 0.15
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -9,7 +9,7 @@ if config_env() == :prod do
       System.get_env("FULFILLMENT_OVERHEAD_PERCENTAGE") || default_fulfillment_overhead_percentage
     )
 
-  config :visilitator, Visilitator.User,
+  config :visilitator, Visilitator.Transaction,
     fulfillment_overhead_percentage: parsed_fulfillment_overhead_percentage
 
   config :visilitator, Visilitator.Repo,

--- a/test/visilitator_test.exs
+++ b/test/visilitator_test.exs
@@ -178,7 +178,7 @@ defmodule VisilitatorTest do
     assert (User |> Repo.get(member.id)).balance == debited_mins
 
     overhead_percent =
-      Application.fetch_env!(:visilitator, Visilitator.User)
+      Application.fetch_env!(:visilitator, Visilitator.Transaction)
       |> Keyword.fetch!(:fulfillment_overhead_percentage)
 
     credited_mins = pal.balance + trunc(visit.minutes - visit.minutes * overhead_percent)


### PR DESCRIPTION
# Description

The math for the transaction belongs in the Transaction object. This simplifies the overall API.